### PR TITLE
Generalize info.txt handling

### DIFF
--- a/siso/__init__.py
+++ b/siso/__init__.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from enum import IntEnum, Enum
+from pathlib import Path
 
 from typing import Dict, Any, Optional, Tuple
 
@@ -119,6 +120,12 @@ class Config(metaclass=ConfigMeta):
 
     # Input coordinate overrides.
     input_coords = Setting({}, Pipeline, name='--in-coords')
+
+    # Use info.txt grid offset
+    offset_file = Setting(None, Pipeline, name="--offset")
+
+    # Expect to find info.txt grid offset
+    offset_should_exist = Setting(False, Pipeline)
 
     # Input endianness indicator. Used by the SIMRA reader.
     input_endianness = Setting('native', Reader, name='--in-endianness')

--- a/siso/coords/__init__.py
+++ b/siso/coords/__init__.py
@@ -93,6 +93,7 @@ class WGS72(ERFAEllipsoid):
 class Coords(ABC):
 
     name: str
+    is_affine: bool
 
     @staticmethod
     def find(name: str) -> 'Coords':
@@ -121,6 +122,7 @@ class Local(Coords):
     """
 
     name = 'local'
+    is_affine = True
 
     specific_name: str
 
@@ -138,6 +140,7 @@ class Geodetic(Coords):
     """Latitude, longitude and height above the reference ellipsoid."""
 
     name = 'geodetic'
+    is_affine = False
 
 
 class UTM(Coords):
@@ -147,6 +150,7 @@ class UTM(Coords):
     zone_letter: str
 
     name = 'utm'
+    is_affine = True
 
     def __init__(self, zone: str):
         self.zone_number = int(zone[:-1])

--- a/siso/pipeline.py
+++ b/siso/pipeline.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, Tuple
 
 from . import config
 from .filters import (
-    Source, LastStepFilter, StepSliceFilter, TesselatorFilter,
+    OffsetFilter, Source, LastStepFilter, StepSliceFilter, TesselatorFilter,
     MergeTopologiesFilter, CoordinateTransformFilter,
 )
 from .coords import Coords, Converter, graph
@@ -68,6 +68,13 @@ def pipeline(reader: Source, writer: Writer):
         reader = MergeTopologiesFilter(reader)
 
     reader = CoordinateTransformFilter(reader, config.coords)
+
+    if config.offset_should_exist and config.offset_file is None:
+        log.warning("Unable to find mesh origin info, coordinates may be unreliable")
+    if config.offset_file is not None:
+        log.info(f"Using {config.offset_file} for offset information")
+        reader = OffsetFilter(reader, config.offset_file)
+
     geometries, fields = discover_fields(reader)
     if not geometries:
         raise ValueError(f"Unable to find any useful geometry fields")

--- a/siso/util.py
+++ b/siso/util.py
@@ -2,14 +2,16 @@ from contextlib import contextmanager
 from functools import partial, wraps
 from itertools import product, chain
 from operator import attrgetter
+from pathlib import Path
 
 import cachetools
 from cachetools.keys import hashkey
 import numpy as np
 from scipy.io import FortranFile
+import treelog as log
 
 from typing import Iterable, Type, TypeVar, Callable, IO
-from .typing import Array
+from .typing import Array2D
 
 
 


### PR DESCRIPTION
Rules:
  - If --no-offset is given, info.txt will not be used
  - If --offset FILENAME is given, that file will be used
  - If neither option is given, info.txt will be used if it is found
  - A warning will be printed if siso expects to find it but can't
    (e.g. for Simra reader).
  - An info message will be printed regardless if info.txt is used
  - A warning will not be printed if siso expects to find it (e.g. for
    Simra reader) but --no-offset has been given.
  - Offsets will be applied after coordinate transformation
  - Offsets will not be applied to affine coordinate systems (e.g.
    lat/lon) where additive transforms make no sense.